### PR TITLE
fix: issue with typings

### DIFF
--- a/lib/maplibre-inspect.ts
+++ b/lib/maplibre-inspect.ts
@@ -1,4 +1,4 @@
-import maplibregl, { MapMouseEvent, SourceSpecification } from 'maplibre-gl';
+import maplibregl, { MapMouseEvent } from 'maplibre-gl';
 import type { Map, Popup, PointLike, StyleSpecification } from 'maplibre-gl';
 import type { Options, RenderPopupFeature } from '../types/maplibre-gl-inspect';
 import './maplibre-gl-inspect.css';
@@ -33,7 +33,7 @@ class MaplibreInspect {
   private _originalStyle: StyleSpecification | null;
   private _toggle: InspectButton;
   public options: Options;
-  public sources: SourceSpecification[];
+  public sources: Options['sources'];
   public assignLayerColor: Options['assignLayerColor'];
 
   constructor(options: Options) {
@@ -55,8 +55,8 @@ class MaplibreInspect {
       );
     }
 
-    this.options = Object.assign(
-      {
+    this.options = {
+      ...{
         showInspectMap: false,
         showInspectButton: true,
         showInspectMapPopup: true,
@@ -73,11 +73,12 @@ class MaplibreInspect {
         useInspectStyle: true,
         queryParameters: {},
         sources: {},
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        toggleCallback() {},
+        toggleCallback(showInspect: boolean) {
+          console.log('Inspector status?: ', showInspect);
+        },
       },
-      options,
-    );
+      ...options,
+    };
 
     this.sources = this.options.sources;
     this.assignLayerColor = this.options.assignLayerColor;
@@ -134,15 +135,15 @@ class MaplibreInspect {
           };
           const layerIds = sourceCache._source.vectorLayerIds;
           if (layerIds) {
-            sources[sourceId] = layerIds;
+            sources[`${sourceId}`] = layerIds;
           } else if (sourceCache._source.type === 'geojson') {
-            sources[sourceId] = [];
+            sources[`${sourceId}`] = [];
           }
         });
 
         Object.keys(sources).forEach((sourceId) => {
           if (mapStyleSourcesNames.indexOf(sourceId) === -1) {
-            delete sources[sourceId];
+            delete sources[`${sourceId}`];
           }
         });
 

--- a/lib/style-gen.ts
+++ b/lib/style-gen.ts
@@ -76,7 +76,7 @@ const lineLayer = (
 };
 
 const generateColoredLayers = (
-  sources: SourceSpecification[],
+  sources: Options['sources'],
   assignLayerColor: Options['assignLayerColor'],
 ): (
   | FillLayerSpecification
@@ -100,7 +100,7 @@ const generateColoredLayers = (
   };
 
   Object.keys(sources).forEach((sourceId) => {
-    const layers = sources[sourceId];
+    const layers = sources[`${sourceId}`] as string[];
 
     if (!layers || layers.length === 0) {
       const colors = alphaColors(sourceId);
@@ -145,13 +145,16 @@ const generateInspectStyle = (
     },
   };
 
-  const sources = {};
+  const sources = {} as {
+    [_: string]: SourceSpecification;
+  };
   Object.keys(originalMapStyle.sources).forEach((sourceId) => {
     const source = originalMapStyle.sources[`${sourceId}`];
     if (source.type === 'vector' || source.type === 'geojson') {
-      sources[sourceId] = source;
+      sources[`${sourceId}`] = source;
     }
   });
+
   return {
     ...originalMapStyle,
     layers: [backgroundLayer, ...coloredLayers],

--- a/types/maplibre-gl-inspect.ts
+++ b/types/maplibre-gl-inspect.ts
@@ -1,8 +1,8 @@
 import type {
-  LayerSpecification,
-  Popup,
   SourceSpecification,
+  LayerSpecification,
   StyleSpecification,
+  Popup,
 } from 'maplibre-gl';
 
 export type RenderPopupProperty = {
@@ -37,6 +37,6 @@ export type Options = {
   selectThreshold: number;
   useInspectStyle: boolean;
   queryParameters: Record<string, string>;
-  sources: SourceSpecification[];
+  sources: { [_: string]: SourceSpecification | string[] };
   toggleCallback(showInspectMap?: boolean): void;
 };


### PR DESCRIPTION
- [x] Correct typings for `sources: ` object

Signed-off-by: Vinayak Kulkarni <19776877+vinayakkulkarni@users.noreply.github.com>